### PR TITLE
Fix Docker container permissions for SQLite database

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,15 +17,14 @@ WORKDIR /app
 # Install curl for health checks (before switching to non-root user)
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
-# Create directory for SQLite database with proper permissions
-RUN mkdir -p /app/data && chmod 755 /app/data
+# Create a non-root user for security
+RUN groupadd -r appuser && useradd -r -g appuser appuser
 
 # Copy the published app
 COPY --from=build /app/publish ./
 
-# Create a non-root user for security
-RUN groupadd -r appuser && useradd -r -g appuser appuser
-RUN chown -R appuser:appuser /app
+# Create directory for SQLite database with proper permissions
+RUN mkdir -p /app/data && chown -R appuser:appuser /app
 USER appuser
 
 # Expose port


### PR DESCRIPTION
- Reorder Dockerfile steps to create user before setting directory ownership
- Ensure appuser has proper write permissions to /app/data directory
- This resolves SQLite Error 14: 'unable to open database file'

🤖 Generated with [Claude Code](https://claude.ai/code)